### PR TITLE
Dispatch changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/text-variant-tune",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "dist/text-variant-tune.js",
   "repository": "https://github.com/editor-js/text-variant-tune",
   "author": "CodeX <team@codex.so>",

--- a/src/index.js
+++ b/src/index.js
@@ -143,6 +143,8 @@ export default class TextVariantTune {
     tune.classList.toggle(this.api.styles.settingsButtonActive, !isEnabled);
 
     this.variant = !isEnabled ? tune.dataset.name : '';
+
+    this.block.dispatchChange();
   }
 
   /**


### PR DESCRIPTION
Currently `onChange` event of `editor` doesn't trigger even though tune setting is changed. To trigger changes, we need to dispatch the change.