### PR TITLE
fix: update github ci package versions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -9,10 +9,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 12
+          node-version: 18
           registry-url: https://registry.npmjs.org/
       - run: yarn
       - run: yarn build
@@ -23,7 +23,7 @@ jobs:
     needs: publish
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Get package info
         id: package
         uses: codex-team/action-nodejs-package-info@v1


### PR DESCRIPTION
Fixes Github actions after packages update to update Node version used by CI

Ref: https://github.com/editor-js/text-variant-tune/actions/runs/9976757999